### PR TITLE
recomendation on apriltag in constants; and the cm heights were wrong

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "cSpell.words": [
+        "apriltag",
+        "apriltags",
+        "atindex",
+        "botpose",
+        "deadband",
+        "endsection",
+    ]
+}

--- a/src/AdvantageScope 1-24-2025.json
+++ b/src/AdvantageScope 1-24-2025.json
@@ -1,26 +1,36 @@
 {
   "hubs": [
     {
-      "x": 9,
-      "y": 4,
-      "width": 1499,
-      "height": 567,
+      "x": -8,
+      "y": -8,
+      "width": 1552,
+      "height": 832,
       "state": {
         "sidebar": {
           "width": 373,
           "expanded": [
-            "/SmartDashboard/Field/Robot",
-            "/Pose/robotPose",
-            "/SmartDashboard/Module 0/RootSpeed",
-            "/SmartDashboard/Module 0/RootDirection",
             "/SmartDashboard/Module 0/RootDirection/Direction",
             "/DriveState/ModuleStates/0",
             "/DriveState/ModuleStates/3",
-            "/DriveState/ModuleTargets/1",
             "/SmartDashboard/Module 0/RootSpeed/Speed",
             "/SmartDashboard/Auto Mode/options",
-            "/PathPlanner",
-            "/SmartDashboard"
+            "/SmartDashboard/TagsBaby",
+            "/DriveState/Pose/rotation",
+            "/DriveState/Pose/translation",
+            "/TagsBaby",
+            "/DriveState/Speeds",
+            "/Pose",
+            "/photonvision",
+            "/SmartDashboard",
+            "/SmartDashboard/Field",
+            "/SmartDashboard/VisionSystemSim-SimPhoton_system",
+            "/SmartDashboard/VisionSystemSim-SimPhoton_system/Sim Field/Robot",
+            "/photonvision/photonvision/targetPose",
+            "/photonvision/photonvision/targetPose/rotation",
+            "/photonvision/photonvision/targetPose/rotation/q",
+            "/Pose/robotPose",
+            "/SmartDashboard/VisionSystemSim-SimPhoton_system/Sim Field",
+            "/SmartDashboard/VisionSystemSim-SimPhoton_system/Sim Field/visibleTargetPoses"
           ]
         },
         "tabs": {
@@ -49,37 +59,66 @@
                     }
                   },
                   {
-                    "type": "ghostLegacy",
-                    "logKey": "NT:/Pose/robotPose",
+                    "type": "swerveStates",
+                    "logKey": "NT:/DriveState/ModuleTargets",
+                    "logType": "SwerveModuleState[]",
+                    "visible": true,
+                    "options": {
+                      "color": "#ff8c00",
+                      "arrangement": "0,1,2,3"
+                    }
+                  },
+                  {
+                    "type": "swerveStates",
+                    "logKey": "NT:/DriveState/ModuleStates",
+                    "logType": "SwerveModuleState[]",
+                    "visible": true,
+                    "options": {
+                      "color": "#ff00ff",
+                      "arrangement": "0,1,2,3"
+                    }
+                  },
+                  {
+                    "type": "visionLegacy",
+                    "logKey": "NT:/SmartDashboard/VisionSystemSim-SimPhoton_system/Sim Field/visibleTargetPoses",
                     "logType": "NumberArray",
                     "visible": true,
                     "options": {
-                      "model": "Bot-Bot Awakens",
+                      "color": "#00ff00",
+                      "size": "normal",
+                      "format": "Translation2d"
+                    }
+                  },
+                  {
+                    "type": "vision",
+                    "logKey": "NT:/photonvision/photonvision/targetPose",
+                    "logType": "Transform3d",
+                    "visible": false,
+                    "options": {
                       "color": "#ffff00",
-                      "format": "Pose2d",
-                      "units": "radians"
+                      "size": "normal"
                     }
                   }
                 ],
                 "game": "2025 Field",
-                "origin": "blue"
+                "origin": "auto"
               },
               "controllerUUID": "atkw82xbnjk76h58q8670idshmt6ulzz",
               "renderer": {
                 "cameraIndex": -1,
                 "orbitFov": 50,
                 "cameraPosition": [
-                  13.690688427157985,
-                  6.162932230891988,
-                  -0.5569269539325303
+                  12.212197687014864,
+                  11.277572796214736,
+                  4.979353536842179
                 ],
                 "cameraTarget": [
-                  -0.8680433117415023,
-                  -1.155990101589167,
-                  -0.9219297522624529
+                  1.743439003609235,
+                  -1.943769395462077,
+                  -1.9582510055330027
                 ]
               },
-              "controlsHeight": 100
+              "controlsHeight": 229
             },
             {
               "type": 9,
@@ -171,11 +210,57 @@
               "type": 4,
               "title": "Table",
               "controller": [
-                "NT:/SmartDashboard/Max Speed"
+                "NT:/TagsBaby/1"
               ],
               "controllerUUID": "mv3h9zxdbm9uh9amzb1lw53fnmq3h79c",
               "renderer": null,
               "controlsHeight": 0
+            },
+            {
+              "type": 2,
+              "title": "Odometry",
+              "controller": {
+                "sources": [
+                  {
+                    "type": "robotLegacy",
+                    "logKey": "NT:/SmartDashboard/Field/Robot",
+                    "logType": "NumberArray",
+                    "visible": true,
+                    "options": {
+                      "format": "Pose2d",
+                      "units": "radians"
+                    }
+                  },
+                  {
+                    "type": "robotLegacy",
+                    "logKey": "NT:/SmartDashboard/Field/Robot",
+                    "logType": "NumberArray",
+                    "visible": true,
+                    "options": {
+                      "format": "Pose2d",
+                      "units": "radians"
+                    }
+                  },
+                  {
+                    "type": "vision",
+                    "logKey": "NT:/TagsBaby/1",
+                    "logType": "Pose3d",
+                    "visible": true,
+                    "options": {
+                      "color": "#00ff00",
+                      "size": "normal"
+                    }
+                  }
+                ],
+                "game": "2025 Field",
+                "bumpers": "auto",
+                "origin": "blue",
+                "orientation": 0,
+                "size": 30
+              },
+              "controllerUUID": "76rbw1osy0qyrp6aqgdo1xibpfzzxk8s",
+              "renderer": null,
+              "controlsHeight": 200
             }
           ]
         }

--- a/src/commands/driveAtTarget.py
+++ b/src/commands/driveAtTarget.py
@@ -1,0 +1,98 @@
+from commands2 import Command
+from wpimath.geometry import Translation2d, Pose2d, Translation3d, Pose3d, Rotation2d, Transform2d, Transform3d, Rotation3d
+from wpimath.units import degrees, radians, degreesToRadians, radiansToDegrees
+import limelight
+import limelightresults
+from phoenix6 import swerve
+from phoenix6.swerve.utility import phoenix_pid_controller,geometry,kinematics
+
+# create a class that extends Command names DriveAtTargetCommand. 
+# It should use the limelight target latest results (and [maybe] the drivetrain pose) to move the robot to a specific orientation relative to a target.
+# The command should be interruptable and should not end on its own.
+# The command should require the drivetrain subsystem.
+
+
+# def add_transforms(transform1, transform2):
+#     '''takes two 3d transforms and returns the sum of the two'''
+#     # Adding the translations and rotations separately
+#     result_translation = transform1.translation() + transform2.translation()
+#     result_rotation = Rotation3d(
+#         transform1.rotation().x + transform2.rotation().x,
+#         transform1.rotation().y + transform2.rotation().y,
+#         transform1.rotation().z + transform2.rotation().z
+#     )
+#     return Transform3d(result_translation, result_rotation)
+    
+
+class DriveAtTargetCommand(Command):
+    def __init__(self, setpointTranslation: Translation2d, drivetrain, latest_parsed_result):
+        super().__init__()
+        self.latest_parsed_result=latest_parsed_result #TODO later; change to using general results so don't wait on the parsing
+        # limelight JSON parsed spec: https://docs.limelightvision.io/docs/docs-limelight/apis/json-results-specification
+        self.vision_valid = latest_parsed_result.validity
+        self.vision_horz_angle = latest_parsed_result.target_x_degrees
+        self.vision_vert_angle = latest_parsed_result.target_y_degrees
+        self.vision_target_consumed_area = latest_parsed_result.target_area
+
+        # self.Kp_angle = 0.01
+        # self.Kp_area = 0.01
+        self.setpoint_angle_x = degreesToRadians(0) #TODO: should this be input?
+        self.setpoint_angle_y = degreesToRadians(0) #TODO: should this be input?
+        self.setpoint_distance = 2 #meters
+        # self.setpoint_area = 0.25 #TODO: should this be input?
+        #not used currently by limelight self.vision_target_skew = latest_parsed_result.target_skew
+        # self.control_rotation = self.Kp_angle * (self.vision_horz_angle - self.setpoint_angle_x)
+        # self.control_forward = (self.Kp_area * (self.vision_target_consumed_area - self.setpoint_area)
+        #                         + self.Kp_angle * (self.vision_vert_angle - self.setpoint_angle_y))
+        dist_side_at_100pct = .5 #meters
+        dist_side_at_10pct = 15.5 #meters
+        def get_distance_from_area(area):
+            b=(1)
+            y=area**0.5
+            m=(.10 - 1.0)/(dist_side_at_10pct - dist_side_at_100pct )           
+            return (y-b)/m + dist_side_at_100pct
+        self.current_distance = get_distance_from_area(self.vision_target_consumed_area)
+
+
+        '''robot_center = Translation3d(0, 0, .05)
+        camera_location_on_robot = Translation3d(.15, 0.0, .5) #TODO: get this from the robot's configuration
+        camera_rotation_on_robot = Rotation3d(0,degreesToRadians(-5),0)
+        camera_transform = Transform3d(camera_location_on_robot, camera_rotation_on_robot)
+        camera_translation_from_XY_plane = add_transforms(camera_transform, Transform3d(robot_center, Rotation3d()))
+        camera_loc_from_XY_plane = Pose3d(camera_translation_from_XY_plane.translation(), camera_translation_from_XY_plane.rotation())
+        print(f'camera location off ground: {camera_loc_from_XY_plane}')
+        target_setpoint_pose = Pose3d(Translation3d(x=2, y=0, z=1.25), Rotation3d(0,0,degreesToRadians(10)))
+        err = Transform3d(camera_loc_from_XY_plane, target_setpoint_pose)
+        print(f'error in camera location: {err}')'''
+
+        self.drivetrain = drivetrain
+        self.addRequirements(drivetrain)
+        self.current_pose_swerve = self.drivetrain.get_state_copy().pose2d
+
+    def execute(self):
+        # self.drivetrain.add_vision_measurement(self.latest_parsed_result.robot_pose, self.latest_parsed_result.timestamp, self.latest_parsed_result.vision_measurement_std_devs)
+        if self.vision_valid:
+            turn_effort = (phoenix_pid_controller()
+            .setPID(0.1, 0.05, 0.05)
+            .setTolerance(degreesToRadians(5))
+            .calculate(self.vision_horz_angle, self.setpoint_angle_x)
+            )
+            forward_effort = (phoenix_pid_controller()
+            .setPID(0.1, 0.05, 0.05)
+            .setTolerance(0.05)
+            .calculate(self.current_distance, self.setpoint_distance)
+            )
+            (swerve.requests.RobotCentric()
+            .with_rotational_rate(turn_effort)
+            .with_velocity_x(forward_effort)
+            .with_velocity_y(-self.control_rotation)
+            )#.schedule())
+
+    def isFinished(self):
+        return False
+
+    def end(self):
+        pass
+
+    def interrupted(self):
+        self.end()

--- a/src/commands/odometry_fuse.py
+++ b/src/commands/odometry_fuse.py
@@ -1,0 +1,28 @@
+from commands2 import Command
+# a drivetrain command
+class VisOdoFuseCommand(Command):
+    
+    def __init__(self, drivetrain, latest_parsed_result):
+        super().__init__()
+        self.latest_parsed_result=latest_parsed_result
+        self.drivetrain = drivetrain
+        # self.limelight = limelight
+        self.addRequirements(drivetrain)# don't really tie up the limelight right? , limelight)
+        self.current_pose_swerve = self.drivetrain.get_state_copy().pose #SwerveDriveState.pose #swerve_drive_state.pose
+
+    def execute(self):
+        # if trust vision data update the drivetrain odometer
+        # trust_vision_data, latest_parsed_result = self.limelight.trust_target(self.current_pose_swerve)
+        print(f'-\n Running the vis-odo-fuse -- current_pose_swerve: {self.current_pose_swerve} -----\nMust Trust if running\n----\n-----------------------------\n-------\n--\n')
+        # if trust_vision_data:
+        self.drivetrain.add_vision_measurement(self.latest_parsed_result.robot_pose, self.latest_parsed_result.timestamp, self.latest_parsed_result.vision_measurement_std_devs)
+    ''''add_vision_measurement(vision_robot_pose: Pose2d, timestamp: phoenix6.units.second, vision_measurement_std_devs: tuple[float, float, float] | None = None)'''
+
+    def isFinished(self):
+        return False
+
+    def end(self): 
+        pass
+
+    def interrupted(self):
+        self.end()

--- a/src/commands/odometry_snap2Line.py
+++ b/src/commands/odometry_snap2Line.py
@@ -1,0 +1,64 @@
+from commands2 import Command
+from wpimath.geometry import Translation2d, Pose2d, Translation3d, Pose3d, Rotation2d, Transform2d, Transform3d, Rotation3d
+from wpimath.units import degrees, radians, degreesToRadians, radiansToDegrees
+import limelight
+import limelightresults
+from phoenix6 import swerve
+# from phoenix6.swerve.utility import phoenix_pid_controller,geometry,kinematics
+import numpy as np
+
+class SnapToLineCommand(Command):
+    '''This command snaps the robot to the closest point on a line segment.
+    The line segments will be the hard walls that the robot could potentially push against.'''
+    def __init__(self, drivetrain, line_start: Translation2d, line_end: Translation2d):
+        super().__init__()
+        self.drivetrain = drivetrain
+        self.line_start = line_start
+        self.line_end = line_end
+        self.addRequirements(drivetrain)
+        self.segments = [(Translation2d(1,1), Translation2d(0,0)), (Translation2d(0,0), Translation2d(1,0)),
+            (Translation2d(1,0), Translation2d(1,1)), (Translation2d(1,1), Translation2d(0,1))] #TODO: make into real segments, import form constants(could use apriltaglayout to help generate)
+
+    def execute(self):
+        current_pose = self.drivetrain.get_state_copy().pose2d
+        (trust_snap, snap_dist, closest_point) = self.get_closest_point_on_segments(current_pose.translation(), segments=self.segments)
+        #TODO: add way to address the rotation of the robot or use self.drivetrain.reset_translation()
+        if trust_snap:
+            self.drivetrain.reset_translation(closest_point)
+        else:
+            pass #TODO add feedback to the driver that the snap was not trusted
+        # closest_pose = Pose2d(closest_point, current_pose.rotation())
+        # self.drivetrain.reset_pose(closest_pose)
+
+    def get_closest_point_on_segments(self, point: Translation2d, segments: list) -> Translation2d:
+        min_snap_dist = float('inf')
+        closest_point = None
+        for start, end in segments:
+            line_vec = end - start
+            point_vec = point - start
+            line_len = line_vec.norm()
+            line_unitvec = line_vec / line_len
+            projection_length = np.dot(point_vec.toVector(), line_unitvec.toVector())
+            projection_length = max(0, min(line_len, projection_length))
+            candidate_point = start + line_unitvec * projection_length
+            snap_dist = (point - candidate_point).norm()
+            if snap_dist < min_snap_dist:
+                min_snap_dist = snap_dist
+                closest_point = candidate_point
+        snap_trust_limit = 1.0
+        trust_snap = min_snap_dist < snap_trust_limit
+        return (trust_snap, min_snap_dist, closest_point)
+    
+
+
+    
+
+
+    def isFinished(self):
+        return True
+
+    def end(self):
+        pass
+
+    def interrupted(self):
+        self.end()

--- a/src/constants.py
+++ b/src/constants.py
@@ -10,7 +10,7 @@ CAM_MOUNT_PITCH = 25
 
 
 AprilTagField=apriltag.AprilTagFieldLayout.loadField(apriltag.AprilTagField(3))
-AprilTags= apriltag.AprilTagFieldLayout.loadField(apriltag.AprilTagField(3)).getTags() #recomend using this instead of the class below
+AprilTags= apriltag.AprilTagFieldLayout.loadField(apriltag.AprilTagField(3)).getTags() #recommend using this instead of the class below
 class AprilTags_height:
     def tag_heights(): #height of apriltags by order of number, in centimeters
         heights = numpy.array([135, 135, 117, 178, 178, 17, 17, 17, 17, 17, 17, 135, 135, 117, 178, 178, 17, 17, 17, 17, 17, 17])
@@ -43,7 +43,7 @@ class AprilTags_height:
 #region RoboRio Constants
 # included to help with communication and readability
 class Rio_DIO(IntEnum):
-    ZERRO = 0
+    ZERO = 0
     ONE = auto()
     TWO = auto()
     THREE = auto()
@@ -64,7 +64,7 @@ class Rio_DIO(IntEnum):
     SEVENTEEN = auto()
 
 class Rio_Pnue(IntEnum):
-    ZERRO = 0
+    ZERO = 0
     ONE = auto()
     TWO = auto()
     THREE = auto()
@@ -101,7 +101,7 @@ class Rio_Analog(IntEnum):
 
 #region CAN Constants
 class CAN_Address(IntEnum):
-    ZERRO = 0
+    ZERO = 0
     ONE = auto()
     TWO = auto()
     THREE = auto()

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -30,14 +30,14 @@ robotpy_version = "2025.2.1.0"#"2025.1.1.1"#"2024.3.2.2"
 # -> equivalent to `pip install robotpy[extra1, ...]
 # fomr PyPi: Provides-Extra: apriltag, commands2, cscore, navx, pathplannerlib, phoenix6, rev, romi, sim, xrp, all
 robotpy_extras = [
-    "all",
+    # "all",
     "apriltag",
     "commands2",
     "cscore",
     "navx",
     "pathplannerlib",
-    "phoenix6",
-    # "photonvision",
+    # "phoenix6", # conflicts with the version specifier below ~25.2
+    # "photonvision",says doesnt have: WARNING: robotpy 2025.2.1.0 does not provide the extra 'photonvision'
     # "playingwithfusion",
     "rev",
     # "romi",
@@ -50,20 +50,23 @@ robotpy_extras = [
     # "opencv",
 ]
 
+
 # Other pip packages to install on the roboRIO
 requires = [
-    "phoenix6~=25.1",
+    "phoenix6~=25.2",
     'numpy',
     'limelightlib-python',
+    'photonlibpy',
     'robotpy-apriltag',
     # 'opencv-python',
     #'scipy'
     'pynetworktables',
     'pyfrc',
+    # 'robotpy-ctre',# conflicts with the version specifier below phoenix6~25.2
+    
     # 'robotpy-hal-sim',
     #'robotpy-wpilib',
     #'robotpy-wpiutil',
-    'robotpy-ctre',
     # 'robotpy-opencv'
     #'robotpy-rev',
 

--- a/src/robot.py
+++ b/src/robot.py
@@ -11,9 +11,7 @@ import typing
 from wpilib import SmartDashboard, Field2d 
 import constants
 
-
 from robotcontainer import RobotContainer
-
 
 class MyRobot(commands2.TimedCommandRobot):
     """
@@ -57,7 +55,7 @@ class MyRobot(commands2.TimedCommandRobot):
         # and running subsystem periodic() methods.  This must be called from the robot's periodic
         # block in order for anything in the Command-based framework to work.
         commands2.CommandScheduler.getInstance().run()
-
+        
         self.container._max_speed = SmartDashboard.getNumber("Max Speed",0.0)
 
     def disabledInit(self) -> None:
@@ -77,6 +75,7 @@ class MyRobot(commands2.TimedCommandRobot):
 
     def autonomousPeriodic(self) -> None:
         """This function is called periodically during autonomous"""
+        # Run the VisOdoFuseCommand ???
         pass
 
     def teleopInit(self) -> None:
@@ -89,6 +88,7 @@ class MyRobot(commands2.TimedCommandRobot):
 
     def teleopPeriodic(self) -> None:
         """This function is called periodically during operator control"""
+        
         pass
 
     def testInit(self) -> None:

--- a/src/robotcontainer.py
+++ b/src/robotcontainer.py
@@ -87,10 +87,10 @@ class RobotContainer:
         # TODO: replace with command import : swerve.requests.DriveAtTargetCommand
         # TODO: create error terms for vision data and target location
         # TODO: implement a PID controller to drive to the target
-        self._driveTargetRelative = (swerve.requests.RobotCentric()
-                                .with_velocity_x(.1)
-                                .with_velocity_y(0.2)
-                                .with_rotational_rate(0.3))
+        # self._driveTargetRelative = (swerve.requests.RobotCentric()
+        #                         .with_velocity_x(.1)
+        #                         .with_velocity_y(0.2)
+        #                         .with_rotational_rate(0.3))
 
         # Path follower
         self._auto_chooser = AutoBuilder.buildAutoChooser("Tests")
@@ -128,9 +128,9 @@ class RobotContainer:
         #take in vision data and update the odometery... there has to be a better way in crte code...
         self._joystick.y().negate().whileTrue( self.vis_odo_fuse_command) #.negate()
         #Focus in on the target and move relative to it
-        self._joystick.rightStick().whileTrue(
-            self.drivetrain.apply_request(lambda: self._driveTargetRelative) #might work until need dynamic values
-        )
+        # self._joystick.rightStick().whileTrue(
+        #     self.drivetrain.apply_request(lambda: self._driveTargetRelative) #might work until need dynamic values
+        # )
 
 
         #endsection vision related commands

--- a/src/robotcontainer.py
+++ b/src/robotcontainer.py
@@ -18,6 +18,10 @@ from wpilib import SmartDashboard
 from wpimath.geometry import Rotation2d
 from wpimath.units import rotationsToRadians
 
+from subsystems import limelight
+from commands.odometry_fuse import VisOdoFuseCommand
+
+
 
 class RobotContainer:
     """
@@ -48,6 +52,7 @@ class RobotContainer:
             .with_drive_request_type(
                 swerve.SwerveModule.DriveRequestType.OPEN_LOOP_VOLTAGE
             )  # Use open-loop control for drive 
+
         )
         self._brake = swerve.requests.SwerveDriveBrake()
         self._point = swerve.requests.PointWheelsAt()
@@ -58,11 +63,23 @@ class RobotContainer:
             )
         )
 
+
         self._logger = Telemetry(self._max_speed)
 
         self._joystick = commands2.button.CommandXboxController(0)
 
         self.drivetrain = TunerConstants.create_drivetrain()
+
+        # Vision
+        self.limelight = limelight.LimelightSubsystem()
+
+        # Run the VisOdoFuseCommand --- put it where?
+        self.current_pose_swerve = self.drivetrain.get_state_copy().pose #SwerveDriveState.pose #swerve_drive_state.pose
+        trust_vision_data, latest_parsed_result = self.limelight.trust_target(self.current_pose_swerve)
+        self.vis_odo_fuse_command =  commands2.ConditionalCommand(VisOdoFuseCommand(self.drivetrain, latest_parsed_result),
+                                                                  commands2.PrintCommand("Not Updating Odometer with Vision Data"),
+                                                                  lambda: trust_vision_data)
+        # self.vis_odo_fuse_command.schedule()
 
         # Path follower
         self._auto_chooser = AutoBuilder.buildAutoChooser("Tests")
@@ -77,12 +94,11 @@ class RobotContainer:
         instantiating a :GenericHID or one of its subclasses (Joystick or XboxController),
         and then passing it to a JoystickButton.
         """
-
         # Note that X is defined as forward according to WPILib convention,
         # and Y is defined as to the left according to WPILib convention.
+        # Drivetrain will execute this command periodically
         self.drivetrain.setDefaultCommand(
-            # Drivetrain will execute this command periodically
-            self.drivetrain.apply_request(
+                self.drivetrain.apply_request(
                 lambda: (
                     self._drive.with_velocity_x(
                         -drive_smoothing.smooth(self._joystick.getLeftY()) * self._max_speed
@@ -94,8 +110,11 @@ class RobotContainer:
                         -drive_smoothing.smooth(self._joystick.getRightX()) * self._max_angular_rate
                     )  # Drive counterclockwise with negative X (left)
                 )
-            )
+            )#.alongWith(commands2.PrintCommand("Running default command. \nq\nqqq\nqqqqqqq\nqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nqqqqqqq\n---\n")),
         )
+        
+        #
+        self._joystick.x().negate().whileTrue( self.vis_odo_fuse_command) #.negate()
 
         self._joystick.a().whileTrue(self.drivetrain.apply_request(lambda: self._brake))
         self._joystick.b().whileTrue(
@@ -136,9 +155,6 @@ class RobotContainer:
         self._joystick.leftBumper().onTrue(
             self.drivetrain.runOnce(lambda: self.drivetrain.seed_field_centric())
         )
-        '''self._joystick.rightBumper().onTrue(
-            self.drivetrain.runOnce(lambda: self.ma.seed_field_centric())
-        )'''
 
         self.drivetrain.register_telemetry(
             lambda state: self._logger.telemeterize(state)

--- a/src/simgui-window.json
+++ b/src/simgui-window.json
@@ -6,13 +6,13 @@
     "GLOBAL": {
       "font": "Proggy Dotted",
       "fps": "120",
-      "height": "466",
-      "maximized": "0",
+      "height": "991",
+      "maximized": "1",
       "style": "0",
       "userScale": "2",
       "width": "1920",
-      "xpos": "11",
-      "ypos": "402"
+      "xpos": "0",
+      "ypos": "29"
     }
   },
   "Table": {
@@ -62,7 +62,7 @@
     "###NetworkTables": {
       "Collapsed": "0",
       "Pos": "375,229",
-      "Size": "937,405"
+      "Size": "937,661"
     },
     "###NetworkTables Info": {
       "Collapsed": "0",

--- a/src/simgui-window.json
+++ b/src/simgui-window.json
@@ -50,7 +50,7 @@
       "Size": "210,214"
     },
     "###Joysticks": {
-      "Collapsed": "1",
+      "Collapsed": "0",
       "Pos": "665,58",
       "Size": "976,278"
     },

--- a/src/simgui-window.json
+++ b/src/simgui-window.json
@@ -6,13 +6,13 @@
     "GLOBAL": {
       "font": "Proggy Dotted",
       "fps": "120",
-      "height": "386",
+      "height": "466",
       "maximized": "0",
       "style": "0",
       "userScale": "2",
       "width": "1920",
-      "xpos": "17",
-      "ypos": "612"
+      "xpos": "11",
+      "ypos": "402"
     }
   },
   "Table": {
@@ -29,6 +29,11 @@
     }
   },
   "Window": {
+    "###/FMSInfo": {
+      "Collapsed": "0",
+      "Pos": "60,60",
+      "Size": "217,194"
+    },
     "###/SmartDashboard/Auto Mode": {
       "Collapsed": "0",
       "Pos": "5,320",
@@ -42,11 +47,11 @@
     "###FMS": {
       "Collapsed": "0",
       "Pos": "6,159",
-      "Size": "336,158"
+      "Size": "210,214"
     },
     "###Joysticks": {
-      "Collapsed": "0",
-      "Pos": "620,45",
+      "Collapsed": "1",
+      "Pos": "665,58",
       "Size": "976,278"
     },
     "###Keyboard 0 Settings": {
@@ -61,7 +66,7 @@
     },
     "###NetworkTables Info": {
       "Collapsed": "0",
-      "Pos": "373,228",
+      "Pos": "493,188",
       "Size": "937,181"
     },
     "###Other Devices": {
@@ -71,7 +76,7 @@
     },
     "###System Joysticks": {
       "Collapsed": "0",
-      "Pos": "633,22",
+      "Pos": "672,23",
       "Size": "232,254"
     },
     "###Timing": {

--- a/src/simgui.json
+++ b/src/simgui.json
@@ -29,10 +29,12 @@
       "/Pose": "Field2d",
       "/SmartDashboard/Auto Mode": "String Chooser",
       "/SmartDashboard/Field": "Field2d",
+      "/SmartDashboard/Field-Vision": "Field2d",
       "/SmartDashboard/Module 0": "Mechanism2d",
       "/SmartDashboard/Module 1": "Mechanism2d",
       "/SmartDashboard/Module 2": "Mechanism2d",
-      "/SmartDashboard/Module 3": "Mechanism2d"
+      "/SmartDashboard/Module 3": "Mechanism2d",
+      "/SmartDashboard/VisionSystemSim-SimPhoton_system/Sim Field": "Field2d"
     },
     "windows": {
       "/SmartDashboard/Auto Mode": {
@@ -69,6 +71,18 @@
     "transitory": {
       "SmartDashboard": {
         "open": true
+      },
+      "photonvision": {
+        "open": true,
+        "photonvision": {
+          "Transform3d##v_/photonvision/photonvision/targetPose": {
+            "Rotation3d##v_rotation": {
+              "open": true
+            },
+            "open": true
+          },
+          "open": true
+        }
       }
     }
   },

--- a/src/subsystems/limelight.py
+++ b/src/subsystems/limelight.py
@@ -1,0 +1,223 @@
+#lifted from https://github.com/LimelightVision/limelightlib-python/tree/main
+
+# look into making a subsystem out of this. Or just use ll imported.
+
+# results specification: https://docs.limelightvision.io/docs/docs-limelight/apis/json-results-specification
+# basic use: https://docs.limelightvision.io/docs/docs-limelight/apis/complete-networktables-api
+
+# command based... floating subsystem.
+
+
+
+import limelight
+import limelightresults
+import json
+import time
+from commands2 import Subsystem
+from wpimath.geometry import Pose2d, Transform2d
+import numpy as np
+
+class LimelightSubsystem(Subsystem):
+    def __init__(self):
+        super().__init__()
+        self.discovered_limelights = limelight.discover_limelights(debug=True)
+        print("discovered limelights:", self.discovered_limelights)
+
+        if self.discovered_limelights:
+            limelight_address = self.discovered_limelights[0] 
+            self.ll = limelight.Limelight(limelight_address)
+            results = self.ll.get_results()
+            status = self.ll.get_status()
+            print("-----")
+            print("targeting results:", results)
+            print("-----")
+            print("status:", status)
+            print("-----")
+            print("temp:", self.ll.get_temp())
+            print("-----")
+            print("name:", self.ll.get_name())
+            print("-----")
+            print("fps:", self.ll.get_fps())
+            print("-----")
+            print("hwreport:", self.ll.hw_report())
+
+            self.ll.enable_websocket()
+            print(self.ll.get_pipeline_atindex(0))
+        '''self.ll.update_pipeline(json.dumps({
+            'area_max': 98.7,
+            'area_min': 1.98778
+        }), flush=1)
+        self.ll.pipeline_switch(1)
+        self.ll.update_python_inputs([4.2,0.1,9.87])
+        self.ll.get_latest_results()
+        self.ll.disable_websocket()'''
+    #disable websocket
+    def disable_websocket(self):
+        return self.ll.disable_websocket()
+
+    #update python inputs
+    def update_python_inputs(self, inputs):
+        return self.ll.update_python_inputs(inputs)
+
+    def get_results(self):
+        return self.ll.get_results()
+    
+    # get latest results
+    def get_latest_results(self):
+        return self.ll.get_latest_results()
+
+    def get_status(self):
+        return self.ll.get_status()
+
+    def get_temp(self):
+        return self.ll.get_temp()
+
+    def get_name(self):
+        return self.ll.get_name()
+
+    def get_fps(self):
+        return self.ll.get_fps()
+
+    def hw_report(self):
+        return self.ll.hw_report()
+
+    def get_pipeline_atindex(self, index):
+        return self.ll.get_pipeline_atindex(index)
+
+    def update_pipeline(self, pipeline_update, flush):
+        return self.ll.update_pipeline(pipeline_update, flush)
+
+    def pipeline_switch(self, index):
+        return self.ll.pipeline_switch(index)
+
+    def update_python_inputs(self, inputs):
+        return self.ll.update_python_inputs(inputs)
+
+    def get_latest_results(self):
+        return self.ll.get_latest_results()
+
+    def disable_websocket(self):
+        return self.ll.disable_websocket()
+
+    def enable_websocket(self):
+        return self.ll.enable_websocket()
+    
+    #section specialty utilities
+    def trust_target(self, robot_pose: Pose2d):
+        #calculate distance to the detected target
+        #will the results hav only one target's results? assume one for now
+        # Done: check unit consistency: botpose is in meters, robot_pose is in meters
+        trust_vision_data = True
+        if self.discovered_limelights:
+            latest_parsed_result = limelightresults.parse_results(self.ll.get_latest_results())
+            validity = latest_parsed_result.validity #what units are validity in ?
+            trust_vision_data *= (validity==1) 
+            delta_x  = latest_parsed_result.botpose[0] - robot_pose.X
+            delta_y = latest_parsed_result.botpose[1] - robot_pose.Y
+            residual = np.sqrt(delta_x**2 + delta_y**2)
+            trust_vision_data *= (residual < 1) 
+            if latest_parsed_result.stddevs:
+                detect_stdDev = latest_parsed_result.stddevs
+                detect_stdDev_x = detect_stdDev[0]
+                detect_stdDev_y = detect_stdDev[1]
+                max_stdDev = max(detect_stdDev_x, detect_stdDev_y)
+                trust_vision_data *= (residual < 2 * max_stdDev) 
+                #if the residual is within 2 standard deviations, 
+                # and the residual is less than 1 meter, 
+                # trust the target
+        else:
+            trust_vision_data = False
+            latest_parsed_result= None
+            '''add_vision_measurement(vision_robot_pose: Pose2d, timestamp: phoenix6.units.second, vision_measurement_std_devs: tuple[float, float, float] | None = None)'''
+
+
+        return (trust_vision_data , latest_parsed_result)
+
+
+    #endsection specialty utilities
+
+    def periodic(self):
+        if self.discovered_limelights:
+            try:
+                while True:
+                    result = self.ll.get_latest_results()
+                    _parsed_result = limelightresults.parse_results(result)
+                    if _parsed_result is not None:
+                        print("valid targets: ", _parsed_result.validity, ", pipelineIndex: ", _parsed_result.pipeline_id,", Targeting Latency: ", _parsed_result.targeting_latency)
+                        self.parsed_result = _parsed_result
+                        
+
+
+                        #for tag in parsed_result.fiducialResults:
+                        #    print(tag.robot_pose_target_space, tag.fiducial_id)
+                    time.sleep(1)  # Set this to 0 for max fps
+            except KeyboardInterrupt:
+                print("Program interrupted by user, shutting down.")
+            finally:
+                self.ll.disable_websocket()
+            # pass
+
+    # def init(self):
+    #     pass
+
+    def end(self):
+        
+        if self.discovered_limelights: self.ll.disable_websocket()
+    
+'''discovered_limelights = limelight.discover_limelights(debug=True)
+print("discovered limelights:", discovered_limelights)
+
+if discovered_limelights:
+    limelight_address = discovered_limelights[0] 
+    ll = limelight.Limelight(limelight_address)
+    results = ll.get_results()
+    status = ll.get_status()
+    print("-----")
+    print("targeting results:", results)
+    print("-----")
+    print("status:", status)
+    print("-----")
+    print("temp:", ll.get_temp())
+    print("-----")
+    print("name:", ll.get_name())
+    print("-----")
+    print("fps:", ll.get_fps())
+    print("-----")
+    print("hwreport:", ll.hw_report())
+
+    ll.enable_websocket()
+   
+    # print the current pipeline settings
+    print(ll.get_pipeline_atindex(0))
+
+    # update the current pipeline and flush to disk
+    pipeline_update = {
+    'area_max': 98.7,
+    'area_min': 1.98778
+    }
+    ll.update_pipeline(json.dumps(pipeline_update),flush=1)
+
+    print(ll.get_pipeline_atindex(0))
+
+    # switch to pipeline 1
+    ll.pipeline_switch(1)
+
+    # update custom user data
+    ll.update_python_inputs([4.2,0.1,9.87])
+    
+    
+    try:
+        while True:
+            result = ll.get_latest_results()
+            parsed_result = limelightresults.parse_results(result)
+            if parsed_result is not None:
+                print("valid targets: ", parsed_result.validity, ", pipelineIndex: ", parsed_result.pipeline_id,", Targeting Latency: ", parsed_result.targeting_latency)
+                #for tag in parsed_result.fiducialResults:
+                #    print(tag.robot_pose_target_space, tag.fiducial_id)
+            time.sleep(1)  # Set this to 0 for max fps
+
+
+    except KeyboardInterrupt:
+        print("Program interrupted by user, shutting down.")
+    finally:
+        ll.disable_websocket()'''


### PR DESCRIPTION
Added some good CTRE Swerve controls I learned; added trim in the rotation; created the class commands we may wnat to devlope: snap to nearest line segment & update with vision.

May wnat to make the snap actually use the 'update with vission' command instead of overriding the odometry.



pheonix 6 swerve: https://api.ctr-electronics.com/phoenix6/latest/python/

add_vision_measurement(vision_robot_pose: Pose2d, timestamp: phoenix6.units.second, vision_measurement_std_devs: tuple[float, float, float] | None = None): https://api.ctr-electronics.com/phoenix6/latest/python/autoapi/phoenix6/swerve/index.html

vision_measurement_std_devs (tuple[float, float, float] | None) – Standard deviations of the vision pose measurement (x position in meters, y position in meters, and heading in radians). Increase these numbers to trust the vision pose measurement less.

set_vision_measurement_std_devs(vision_measurement_std_devs: tuple[float, float, float])
Sets the pose estimator’s trust of global measurements. 

To start with some common language on variables: https://github.com/LimelightVision/limelightlib-python/tree/main
